### PR TITLE
Add Moralis Integration for Ethereum and Aptos Token Balances

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,6 +1,9 @@
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { MoralisModule } from './moralis/moralis.module';
+import { MoralisService } from './moralis/moralis.service';
+import { MoralisController } from './moralis/moralis.controller';
 import { ConfigModule } from '@nestjs/config';
 import { SolanaController } from './solana/solana.controller';
 import { SolanaService } from './solana/solana.service';
@@ -11,13 +14,14 @@ import { CcipModule } from './ccip/ccip.module';
 
 @Module({
   imports: [
+    MoralisModule,
     ConfigModule.forRoot({
       isGlobal: true,
     }),
     SolanaModule,
     CcipModule,
   ],
-  controllers: [AppController, SolanaController, CcipController],
-  providers: [AppService, SolanaService, CcipService],
+  controllers: [AppController, SolanaController,  CcipController],
+  providers: [AppService, SolanaService,  CcipService],
 })
 export class AppModule {}

--- a/src/moralis/moralis.controller.spec.ts
+++ b/src/moralis/moralis.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MoralisController } from './moralis.controller';
+
+describe('MoralisController', () => {
+  let controller: MoralisController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [MoralisController],
+    }).compile();
+
+    controller = module.get<MoralisController>(MoralisController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/moralis/moralis.controller.ts
+++ b/src/moralis/moralis.controller.ts
@@ -1,0 +1,47 @@
+import { Controller, Get, Query, ParseIntPipe } from '@nestjs/common';
+import { MoralisService } from './moralis.service';
+
+@Controller('moralis')
+export class MoralisController {
+  constructor(private readonly moralisService: MoralisService) {}
+
+  @Get('ethereumTokenBalances')
+  async getWalletTokenBalances(
+    @Query('chain') chain: string,
+    @Query('address') address: string,
+  ) {
+    try {
+      const tokenBalances = await this.moralisService.getWalletTokenBalancesPrice(
+        chain,
+        address,
+      );
+      return tokenBalances;
+    } catch (error) {
+      console.error(error);
+      throw error;
+    }
+  }
+
+  @Get('walletTokenBalancesPriceAptos')
+  async getSPL(
+    @Query('limit', new ParseIntPipe()) limit: number,
+    @Query('address') ownerAddress: string,
+    @Query('network') network: string,
+  ) {
+    try {
+      const ownerAddresses: string[] = [ownerAddress];
+      const tokenBalances = await this.moralisService.getSPL(
+        
+    
+        limit,
+        ownerAddresses,
+        network,
+        
+      );
+      return tokenBalances;
+    } catch (error) {
+      console.error(error);
+      throw error;
+    }
+  }
+}

--- a/src/moralis/moralis.module.ts
+++ b/src/moralis/moralis.module.ts
@@ -1,0 +1,12 @@
+import { Module} from '@nestjs/common';
+import { HttpModule } from '@nestjs/axios';
+import { MoralisController } from './moralis.controller';
+import { MoralisService } from './moralis.service';
+
+
+@Module({
+  imports: [HttpModule],
+  controllers: [MoralisController],
+  providers: [MoralisService]
+})
+export class MoralisModule {}

--- a/src/moralis/moralis.service.spec.ts
+++ b/src/moralis/moralis.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MoralisService } from './moralis.service';
+
+describe('MoralisService', () => {
+  let service: MoralisService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [MoralisService],
+    }).compile();
+
+    service = module.get<MoralisService>(MoralisService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/moralis/moralis.service.ts
+++ b/src/moralis/moralis.service.ts
@@ -1,0 +1,69 @@
+import { Injectable } from '@nestjs/common';
+import { HttpService } from '@nestjs/axios';
+import { ConfigService } from '@nestjs/config';
+import Moralis from 'moralis';
+
+
+@Injectable()
+export class MoralisService {
+  private isInitialized = false;
+
+  constructor(private httpService: HttpService, private configService: ConfigService) {}
+
+  private async initializeMoralis() {
+    if (!this.isInitialized) {
+      try {
+        console.log('Initializing Moralis...',process.env.MORALIS_API_KEY);
+        await Moralis.start({
+          apiKey: this.configService.get<string>('MORALIS_API_KEY'),
+        });
+        this.isInitialized = true;
+        console.log('Moralis initialized successfully');
+      } catch (error) {
+        console.error('Failed to initialize Moralis:', error);
+        throw error;
+      }
+    }
+  }
+
+  async getWalletTokenBalancesPrice(chain: string, address: string) {
+    try {
+      await this.initializeMoralis();
+
+      const response = await Moralis.EvmApi.wallets.getWalletTokenBalancesPrice({
+        chain,
+        address,
+      });
+
+      return response.result;
+    } catch (error) {
+      console.error('Failed to fetch wallet token balances and prices:', error);
+      if (error.response) {
+        // Log the response from the server if available
+        console.error('Response:', error.response.data);
+      }
+      throw error;
+    }
+  }
+
+  async getSPL(limit: number, ownerAddresses: string[], network: string) {
+    try {
+      await this.initializeMoralis();
+
+      const response = await Moralis.AptosApi.wallets.getCoinBalancesByWallets({
+        limit,
+        ownerAddresses,
+        network,
+      });
+
+      return response.result;
+    } catch (error) {
+      console.error('Failed to fetch wallet token balances and prices:', error);
+      if (error.response) {
+        // Log the response from the server if available
+        console.error('Response:', error.response.data);
+      }
+      throw error;
+    }
+  }
+}


### PR DESCRIPTION
Key Features:

**_Moralis Module:_**

**MoralisController:**

- Added GET /moralis/ethereumTokenBalances to fetch Ethereum wallet token balances and prices.
- Added GET /moralis/walletTokenBalancesPriceAptos to fetch SPL token balances for Aptos wallets with a specified limit on the number of results.

**MoralisService:**

- Integrated Moralis API for interacting with Ethereum and Aptos blockchain.
- Implemented initializeMoralis method to ensure Moralis is properly initialized before making any API calls.
- Implemented getWalletTokenBalancesPrice method to fetch Ethereum wallet token balances along with their prices.
- Implemented getSPL method to fetch SPL token balances for specified Aptos wallet addresses with a limit on the number of tokens returned.